### PR TITLE
psi_distributor calls UpdateIndex on nasset_token_rewards

### DIFF
--- a/contracts/psi_distributor/src/commands.rs
+++ b/contracts/psi_distributor/src/commands.rs
@@ -47,7 +47,7 @@ pub fn distribute_rewards(deps: DepsMut, env: Env) -> ContractResult<Response> {
         })));
 
         messages.push(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: config.psi_token.to_string(),
+            contract_addr: config.nasset_token_rewards_contract.to_string(),
             funds: vec![],
             msg: to_binary(&NAssetTokenRewardsExecuteMsg::Anyone {
                 anyone_msg: NAssetTokenRewardsAnyoneMsg::UpdateGlobalIndex {},

--- a/contracts/psi_distributor/src/tests/distribute.rs
+++ b/contracts/psi_distributor/src/tests/distribute.rs
@@ -37,7 +37,7 @@ fn distribute_rewards() {
                 .unwrap(),
             })),
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: PSI_TOKEN_ADDR.to_string(),
+                contract_addr: NASSET_TOKEN_REWARDS_CONTRACT_ADDR.to_string(),
                 funds: vec![],
                 msg: to_binary(&NAssetTokenRewardsExecuteMsg::Anyone {
                     anyone_msg: NAssetTokenRewardsAnyoneMsg::UpdateGlobalIndex {},
@@ -91,7 +91,7 @@ fn distribute_rewards_enought_only_for_nasset_holders() {
                 .unwrap(),
             })),
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: PSI_TOKEN_ADDR.to_string(),
+                contract_addr: NASSET_TOKEN_REWARDS_CONTRACT_ADDR.to_string(),
                 funds: vec![],
                 msg: to_binary(&NAssetTokenRewardsExecuteMsg::Anyone {
                     anyone_msg: NAssetTokenRewardsAnyoneMsg::UpdateGlobalIndex {},
@@ -127,7 +127,7 @@ fn distribute_rewards_enought_for_nasset_holders_and_governance() {
                 .unwrap(),
             })),
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: PSI_TOKEN_ADDR.to_string(),
+                contract_addr: NASSET_TOKEN_REWARDS_CONTRACT_ADDR.to_string(),
                 funds: vec![],
                 msg: to_binary(&NAssetTokenRewardsExecuteMsg::Anyone {
                     anyone_msg: NAssetTokenRewardsAnyoneMsg::UpdateGlobalIndex {},


### PR DESCRIPTION
psi_distributor calls UpdateIndex on nasset_token_rewards now, instead of calling it on psi_token